### PR TITLE
Added emergency stop ability

### DIFF
--- a/X113647Stepper.cpp
+++ b/X113647Stepper.cpp
@@ -51,11 +51,22 @@ X113647Stepper::X113647Stepper(int number_of_steps, int motor_pin_1, int motor_p
 }
 
 /*
-  Common (private) method to initialise stepper output
+  Emergency Stop - sets steps_remaining = 0 so step(int) should stop looping
+  when an interrupt returns into the loop.
+ */
+void X113647Stepper::estop()
+{
+  this->steps_remaining = 0;
+}
 
+/*
+  Common (private) method to initialise stepper output
 */
 void X113647Stepper::ignition()
 {
+  // set steps_remaining to zero
+  this->steps_remaining = 0;
+
   // common instance variable initialisation
   this->step_number = 0;
 
@@ -107,7 +118,8 @@ void X113647Stepper::ignition()
 void X113647Stepper::setSpeed(float whatSpeed)
 {
   this->step_delay = 60L * 1000L / this->number_of_steps / whatSpeed / this->signals_per_step;
-  if(this->step_delay < this->minimum_delay) this->step_delay = this->minimum_delay;
+  if(this->step_delay < this->minimum_delay)
+    this->step_delay = this->minimum_delay;
 }
 
 /*
@@ -116,7 +128,7 @@ void X113647Stepper::setSpeed(float whatSpeed)
  */
 void X113647Stepper::step(int steps_to_move)
 {
-  int steps_remaining = abs(steps_to_move) * this->signals_per_step;  // how many steps to take
+  this->steps_remaining = abs(steps_to_move) * this->signals_per_step;  // how many steps to take
 
   // determine direction based on whether steps_to_move is + or -:
   int direction = 1;                    // Direction of rotation: default forward
@@ -125,7 +137,7 @@ void X113647Stepper::step(int steps_to_move)
   unsigned long last_step_time = 0;     // time stamp in ms of when the last step was taken
 
   // decrement the number of steps, moving one step each time:
-  while(steps_remaining > 0) {
+  while(this->steps_remaining > 0) {
 
     // move only if the appropriate delay has passed:
     if (millis() >= last_step_time + this->step_delay) {
@@ -148,7 +160,7 @@ void X113647Stepper::step(int steps_to_move)
         this->step_number--;
       }
       // decrement the steps remaining:
-      steps_remaining--;
+      this->steps_remaining--;
       // step the motor to step number 0..7:
       stepMotor(this->step_number % this->steps_per_cycle);
     }

--- a/X113647Stepper.h
+++ b/X113647Stepper.h
@@ -53,6 +53,7 @@ class X113647Stepper {
     int steps_per_cycle;         // number of steps per revolution (before gearing)
     int signals_per_step;        // number of signals per step. when full step == 1, when half-step == 2
     int step_number;             // which step the motor is on
+    volatile int steps_remaining; // number of steps remaining in step()
 
     // motor pin numbers:
     int motor_pin_1;
@@ -65,4 +66,3 @@ class X113647Stepper {
 };
 
 #endif
-

--- a/examples/EmergencyStop/EmergencyStop.ino
+++ b/examples/EmergencyStop/EmergencyStop.ino
@@ -1,0 +1,56 @@
+
+/*
+ X113647 Stepper Motor Control - one revolution with emergency stop ISR
+
+ This program drives a 4-Phase 5-Wire stepper motor using 4 wires
+ via an X113647 (ULN2003-based) driver board.
+
+ The motor is attached to digital pins 8 - 11 of the Arduino.
+
+ The motor should revolve one revolution in one direction, then
+ one revolution in the other direction.
+
+ */
+
+#include <X113647Stepper.h>
+
+const int stepsPerRevolution = 64 * 32;  // change this to fit the number of steps per revolution for your motor
+volatile boolean stopped = FALSE;
+
+// initialize the stepper library on pins 8 through 11:
+X113647Stepper myStepper(stepsPerRevolution, 8, 9, 10, 11);
+
+
+void setup() {
+  // set the speed in rpm:
+  myStepper.setSpeed(6.5);
+
+  // put an emergency stop button on pin 2 or 3 (we can attach an interrupt on these pins)
+  // the pin uses internal pullup resistors, so button can just ground the pin.
+  pinMode(2, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(2), eStop, FALLING);
+}
+
+void loop()
+{
+  // step one revolution  in one direction:
+  if(!stopped)
+  {
+    myStepper.step(stepsPerRevolution);
+    delay(500);
+  }
+
+  // step one revolution in the other direction:
+  if(!stopped)
+  {
+    myStepper.step(-stepsPerRevolution);
+    delay(500);
+  }
+}
+
+void eStop()
+{
+  myStepper.estop(); // stop the motor first
+  stopped = true;    // make sure motor won't start on next loop()
+
+}


### PR DESCRIPTION
I added an `estop()` method to X113647 so an interrupt can stop the motor in an emergency. I also provided an example of how it could be used. The example is based on your FullSweep example.

Unfortunately, I am unable to test it for real as I don't have a board and motor right now, but doing some tests with Serial.println() it appears to be working as expected.