### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,7 +13,7 @@ X113647Stepper	KEYWORD1
 #######################################
 
 step	KEYWORD2
-setSpeed  KEYWORD2
+setSpeed	KEYWORD2
 emergencyStop	KEYWORD2
 version	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords